### PR TITLE
feat: add designer list API, designer 상세 API

### DIFF
--- a/app/api/designer.py
+++ b/app/api/designer.py
@@ -1,0 +1,48 @@
+from typing import List, Optional
+
+from bson import ObjectId
+from fastapi import APIRouter, HTTPException, Query, Request, status
+
+from app.schemas.designer_schema import DesignerListResponse, DesignerResponse
+from app.services.designer_service import get_designer, get_designer_list
+
+designer_router = APIRouter()
+
+@designer_router.get("/", response_model=DesignerListResponse)
+async def designer_list_endpoint(
+                                region: Optional[List[str]] = Query(None),
+                                available_modes: Optional[str] = Query(None),
+                                min_consulting_fee: Optional[int] = Query(None),
+                                max_consulting_fee: Optional[int] = Query(None)
+    ):
+    try:
+        designer_list = await get_designer_list(region, available_modes, min_consulting_fee, max_consulting_fee)
+        return designer_list
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"오류 : {str(e)}"
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"오류 : {str(e)}"
+        )
+@designer_router.get("/{designer_id}", response_model=DesignerResponse)
+async def designer_endpoint(designer_id: str):
+    try:
+        if not ObjectId.is_valid(designer_id):
+            raise ValueError(f"디자이너 아이디가 올바르지 않습니다.: {designer_id}")
+
+        designer = await get_designer(designer_id)
+        return designer
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"오류 : {str(e)}"
+        )
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"오류 : {str(e)}"
+        )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -53,5 +53,8 @@ class Settings(BaseSettings):
         kst = pytz.timezone('Asia/Seoul')
         return datetime.now(kst).isoformat()
 
+    @property
+    def DESIGNER_REGIONS(self) -> list[str]:
+        return ['홍대/연남/합정', '강남/청담/압구정', '성수/건대', '서울 전체']
 
 settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
-from app.api import test, reservation, auth, user
+from app.api import test, reservation, auth, user, designer
 from app.core.config import settings
 from app.db.session import get_database
 # 결제
@@ -125,6 +125,8 @@ app.include_router(test.router, prefix="/test", tags=["test"])
 app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(reservation.router,prefix="/reservation", tags=["reservation"])
 app.include_router(user.router, prefix="/user", tags=["user"])
+app.include_router(designer.designer_router, prefix="/designers", tags=["designers"])
+
 # 결제 
 app.include_router(payment_router)
 

--- a/app/repository/designer_repository.py
+++ b/app/repository/designer_repository.py
@@ -1,0 +1,55 @@
+from typing import List, Optional
+
+from bson import ObjectId
+
+from app.core.config import settings
+from app.db.session import get_database
+
+DESIGNER_REGIONS = settings.DESIGNER_REGIONS
+
+async def get_designers(region: Optional[List[str]], available_modes: Optional[str], min_consulting_fee: Optional[int], max_consulting_fee: Optional[int]):
+    db = get_database()
+    designer_collection = db["designers"]
+
+    query = {}
+
+    selected_regions = region if region else DESIGNER_REGIONS
+    if not region or "서울 전체" in region:
+        query["region"] = {"$in": DESIGNER_REGIONS}
+    else:
+        query["region"] = {"$in": region}
+
+    if available_modes:
+        query["available_modes"] = {"$regex": f"(^|, ){available_modes}(, |$)", "$options": "i"}
+    
+    price_filter = {}
+
+    if min_consulting_fee is not None:
+        price_filter["$gte"] = min_consulting_fee  # 최소 금액 설정
+
+    if max_consulting_fee is not None:
+        price_filter["$lte"] = max_consulting_fee  # 최대 금액 설정
+
+    if available_modes == "대면":
+        if price_filter:
+            query["face_consulting_fee"] = price_filter  # 대면만 필터링
+
+    elif available_modes == "비대면":
+        if price_filter:
+            query["non_face_consulting_fee"] = price_filter  # 비대면만 필터링
+
+    else: 
+        if price_filter:
+            query["$or"] = [
+                {"face_consulting_fee": price_filter},
+                {"non_face_consulting_fee": price_filter},
+            ]
+
+    designers_cursor = designer_collection.find(query if query else {})
+    return await designers_cursor.to_list(length=None)
+
+
+async def get_designer_by_designer_id(designer_id: str):
+    db = get_database()
+    designer_collection = db["designers"]
+    return await designer_collection.find({"_id": ObjectId(designer_id)}).to_list(length=None)

--- a/app/schemas/designer_schema.py
+++ b/app/schemas/designer_schema.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import List
+
+from pydantic import BaseModel
+
+class Designer(BaseModel):
+    id: str
+    name: str
+    region: str
+    shop_address: str
+    profile_image: str
+    specialties: str
+    face_consulting_fee: int
+    non_face_consulting_fee: int
+    introduction: str
+    available_modes: str
+    create_at: datetime
+    update_at: datetime
+
+
+class DesignerResponse(BaseModel):
+    id: str
+    name: str
+    region: str
+    shop_address: str
+    profile_image: str
+    specialties: str
+    face_consulting_fee: int
+    non_face_consulting_fee: int
+    introduction: str
+    available_modes: str
+
+class DesignerListResponse(BaseModel):
+    designer_list: List[DesignerResponse]

--- a/app/services/designer_service.py
+++ b/app/services/designer_service.py
@@ -1,0 +1,60 @@
+import logging
+from datetime import datetime
+
+import pytz
+from bson import ObjectId
+from typing import List, Optional
+
+from app.repository.designer_repository import get_designer_by_designer_id, get_designers
+from app.schemas.designer_schema import DesignerListResponse, DesignerResponse
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+kst = pytz.timezone("Asia/Seoul")
+
+async def get_designer_list(region: Optional[List[str]], available_modes: Optional[str], min_consulting_fee: Optional[int], max_consulting_fee: Optional[int]) -> DesignerListResponse:
+    
+    designer_list = await get_designers(region, available_modes, min_consulting_fee, max_consulting_fee)
+    logger.info(f"디자이너 리스트 조회 총: {len(designer_list)} 건")
+    
+    result = []
+    for designer in designer_list:
+        designer_result = DesignerResponse(
+            id=str(designer.get("_id", "")),
+            name=designer.get("name", ""),
+            region=designer.get("region", ""),
+            shop_address=designer.get("shop_address", ""),
+            profile_image=designer.get("profile_image", ""),
+            specialties=designer.get("specialties", ""),
+            face_consulting_fee=designer.get("face_consulting_fee", 0),
+            non_face_consulting_fee=designer.get("non_face_consulting_fee", 0),
+            introduction=designer.get("introduction", ""),
+            available_modes=designer.get("available_modes", "")
+        )
+        result.append(designer_result)
+
+    response = DesignerListResponse(designer_list=result)
+    return response
+
+async def get_designer(designer_id: str) -> DesignerResponse:
+        
+    designer = await get_designer_by_designer_id(designer_id)
+    if not designer:
+        raise ValueError("디자이너 정보가 없습니다.")
+    
+    designer = designer[0]
+    designer_result = DesignerResponse(
+        id=str(designer.get("_id", "")),
+        name=designer.get("name", ""),
+        region=designer.get("region", ""),
+        shop_address=designer.get("shop_address", ""),
+        profile_image=designer.get("profile_image", ""),
+        specialties=designer.get("specialties", ""),
+        face_consulting_fee=designer.get("face_consulting_fee", 0),
+        non_face_consulting_fee=designer.get("non_face_consulting_fee", 0),
+        introduction=designer.get("introduction", ""),
+        available_modes=designer.get("available_modes", "")
+    )
+    return designer_result


### PR DESCRIPTION
## 기능 구현
### 디자이너 list API(GET /designers)
- 파라미터 필터를 사용한 리스트
- 지역 중복 선택 가능
- '대면', '비대면' 중복 선택 불가(선택을 안하거나 '대면, 비대면' 선택해야함)
- '최대 요금' 혹은 '최소 요금'을 설정한 경우
    - '대면'을 선택한 경우, '대면, 비대면', '대면' 정보 중 최대 최소 요금 안에서 필터링
    - '비대면'을 선택한 경우, '대면, 비대면', '비대면'  중 최대 최소 요금 안에서 필터링
    - '대면' 과 '비대면' 선택을 안한경우, '대면', '비대면'에 속한 최소 최대 요금 안에서 필터링
```
  region : '홍대/연남/합정', '강남/청담/압구정', '성수/건대', '서울 전체' 중에 중복 선택 가능 
  available_modes: '대면', '비대면', '대면, 비대면'
  min_consulting_fee: 최소 요금
  max_consulting_fee: 최소 요금
```
### 디자이너 상세 API(GET /designers/{designer_id})
- 디자이너 id 로 디자이너 상세 정보 확인 가능.
- return
```
    id: str
    name: str
    region: str
    shop_address: str
    profile_image: str
    specialties: str
    face_consulting_fee: int
    non_face_consulting_fee: int
    introduction: str
    available_modes: str
```


