### PR TITLE
예약 API 엔드포인트의 HTTP 메서드를 변경, 에러 메시지 한글화

### DIFF
--- a/app/api/reservation.py
+++ b/app/api/reservation.py
@@ -44,7 +44,7 @@ async def reservation_list_endpoint(request: ReservationCreateRequest):
         )
 
 # 예약 리스트
-@router.get("/get_list", response_model=List[ReservationSimple])
+@router.post("/get_list", response_model=List[ReservationSimple])
 async def read_reservations(user_id: str):
     try:
         reservations = await get_reservations_list_by_user_id(user_id)
@@ -62,7 +62,7 @@ async def read_reservations(user_id: str):
             detail=f"오류 : {str(e)}"
         )
 
-@router.get("/get_detail", response_model=ReservationDetail)
+@router.post("/get_detail", response_model=ReservationDetail)
 async def read_reservation(reservation_id: str):
     try:
         reservations = await get_reservation_by_id(reservation_id)

--- a/app/services/reservation_service.py
+++ b/app/services/reservation_service.py
@@ -261,7 +261,7 @@ async def generate_google_meet_link_service(reservation_id: str) -> GoogleMeetLi
         raise ValueError("Reservation not found")
 
     if reservation["mode"] != "비대면":
-        raise ValueError("This user is not remote mode - not allowed to get google meet link")
+        raise ValueError("비대면 모드가 아닙니다. Google Meet링크를 생성할 수 없습니다.")
 
     # 구글 밋 링크 생성 (목 데이터 사용)
     google_meet_link = "https://meet.google.com/mockdata"


### PR DESCRIPTION
### 주요 변경 사항:
- **API 엔드포인트 수정**
  - `app/api/reservation.py`에서 예약 목록 조회 엔드포인트의 HTTP 메서드를 `GET`에서 `POST`로 변경 (`async def read_reservations(user_id: str)`)
  - `app/api/reservation.py`에서 예약 상세 조회 엔드포인트의 HTTP 메서드를 `GET`에서 `POST`로 변경 (`async def read_reservation(reservation_id: str)`)

- **에러 메시지 한글화**
  - `app/services/reservation_service.py`에서 `async def generate_google_meet_link_service(reservation_id: str)` 함수의 에러 메시지를 한국어로 변경