### PR TITLE
Feat: delete_waiting_reservations 함수 구현 및 스케줄러 등록

### DIFF
--- a/app/scheduler/schedulers.py
+++ b/app/scheduler/schedulers.py
@@ -57,11 +57,11 @@ async def delete_waiting_reservations():
     # 업데이트 전에 조건에 맞는 _id 조회
     matching_docs = await db["reservations"].find(delete_filter, {"_id": 1}).to_list(length=None)
     update_ids = [doc["_id"] for doc in matching_docs]
-    logger.info(f"[{now.isoformat()}] 예약대기 _id: {update_ids}")
+    logger.info(f"[{now.isoformat()}] 예약대기 _ids: {update_ids}")
 
     # 조건에 맞는 문서들의 del_yn을 "Y"로 업데이트
-    result = await db["reservations"].update_many(delete_filter, {"$set": {"del_yn": "Y"}})
-    logger.info(f"[{now.isoformat()}] {result.modified_count}건 예약대기 데이터 삭제완료.")
+    result = await db["reservations"].update_many(delete_filter, {"$set": {"status": "예약취소"}})
+    logger.info(f"[{now.isoformat()}] {result.modified_count}건 예약대기 데이터 예약취소처리.")
 
 
 # 스케줄러 설정


### PR DESCRIPTION
- settings.CURRENT_DATETIME를 기준으로 현재 시간을 구하고, 24시간 전 시간을 threshold로 계산합니다.
- "예약대기" 상태이며, update_at이 threshold(24시간 전)보다 이전이고, del_yn이 "N"인 예약 데이터를 대상으로 조회 후 _id를 로깅합니다.
- 조건에 맞는 예약 데이터의 status 값을 "예약취소"로 업데이트하여 예약 취소 처리를 진행합니다.
- 업데이트 결과(수정 건수)를 로깅하며, 스케줄러에 5분마다 실행되도록 등록하였습니다.