### PR TITLE
feat: 소개 페이지 관련 API 및 템플릿 추가

### DIFF
--- a/app/api/introduce.py
+++ b/app/api/introduce.py
@@ -1,0 +1,29 @@
+import os
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+router = APIRouter()
+
+@router.get("/", response_class=HTMLResponse)
+async def introduce():
+    # templates 폴더에서 introduce.html 파일 경로 설정
+    html_path = os.path.join(os.getcwd(), "app", "templates", "introduce.html")
+    
+    # HTML 파일이 존재하는지 확인
+    if os.path.exists(html_path):
+        with open(html_path, "r", encoding="utf-8") as f:
+            html_content = f.read()
+        return html_content
+    else:
+        # 파일이 없는 경우 오류 메시지 제공
+        return """
+        <html>
+            <head>
+                <title>소개 페이지</title>
+            </head>
+            <body>
+                <h1>오류 발생</h1>
+                <p>introduce.html 파일을 찾을 수 없습니다.</p>
+            </body>
+        </html>
+        """

--- a/app/main.py
+++ b/app/main.py
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse, FileResponse
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 
-from app.api import test, reservation, auth, user, designer, bi
+from app.api import test, reservation, auth, user, designer, bi, introduce
 from app.core.config import settings
 from app.db.session import get_database
 # 결제
@@ -137,6 +137,7 @@ app.include_router(reservation.router,prefix="/reservation", tags=["reservation"
 app.include_router(user.router, prefix="/user", tags=["user"])
 app.include_router(designer.designer_router, prefix="/designers", tags=["designers"])
 app.include_router(bi.router, prefix="/bi", tags=["BI"])
+app.include_router(introduce.router, prefix="/introduce", tags=["introduce"])
 
 # 결제 
 app.include_router(payment_router)

--- a/app/templates/introduce.html
+++ b/app/templates/introduce.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>마비노기 모바일 우연한만남 DISCORD</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;500;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      --clr-bg: #f0f2f5;
+      --clr-dark: #23272A;
+      --clr-card: #2C2F33;
+      --clr-accent: #7289DA;
+      --clr-light: #FFFFFF;
+      --clr-muted: #B9BBBE;
+    }
+    * { box-sizing: border-box; margin:0; padding:0; }
+    body {
+      font-family: 'Poppins', sans-serif;
+      background: var(--clr-bg);
+      color: #333;
+      line-height:1.6;
+    }
+    a { text-decoration:none; }
+    .container { max-width:1000px; margin:auto; padding:20px; }
+
+    /* Hero */
+    .hero {
+      background: var(--clr-dark) url('assets/hero-bg.jpg') center/cover no-repeat;
+      color: var(--clr-light);
+      text-align:center;
+      padding:80px 20px;
+    }
+    .hero h1 { font-size:2.5rem; margin-bottom:.5rem; }
+    .hero p { font-size:1.1rem; color:var(--clr-muted); margin-bottom:1.5rem; }
+    .hero .btn {
+      background:var(--clr-accent);
+      color:var(--clr-light);
+      padding:12px 28px;
+      border:none;
+      border-radius:6px;
+      font-size:1rem;
+      cursor:pointer;
+    }
+    .hero .btn:hover { background:#5b6eae; }
+
+    /* Features */
+    .features {
+      display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(240px,1fr));
+      gap:20px;
+      margin-top:40px;
+    }
+    .feature {
+      background:var(--clr-card);
+      color:var(--clr-light);
+      border-radius:8px;
+      padding:24px;
+      text-align:center;
+      box-shadow:0 2px 6px rgba(0,0,0,0.2);
+    }
+    .feature .icon { font-size:2.5rem; margin-bottom:12px; }
+    .feature h3 { margin-bottom:8px; font-size:1.2rem; }
+    .feature p { font-size:.95rem; color:var(--clr-muted); }
+
+    /* Event */
+    .event {
+      background:var(--clr-light);
+      border-radius:8px;
+      padding:24px;
+      margin:60px 0;
+      box-shadow:0 2px 6px rgba(0,0,0,0.1);
+    }
+    .event h2 { font-size:1.5rem; margin-bottom:16px; text-align:center; }
+    .event ul { list-style:none; margin-top:12px; }
+    .event li {
+      margin-bottom:8px;
+      padding-left:1.2em;
+      position:relative;
+      color:#333;
+    }
+    .event li:before {
+      content:"🎁";
+      position:absolute;
+      left:0;
+      top:0;
+    }
+
+    /* Footer */
+    footer {
+      text-align:center;
+      margin:40px 0 20px;
+    }
+    footer .btn {
+      background:var(--clr-accent);
+      color:var(--clr-light);
+      padding:12px 28px;
+      border:none;
+      border-radius:6px;
+      font-size:1rem;
+      cursor:pointer;
+    }
+    footer .btn:hover { background:#5b6eae; }
+
+    @media (max-width:600px) {
+      .hero h1 { font-size:2rem; }
+      .features { grid-template-columns:1fr; }
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Hero Section -->
+  <header class="hero">
+    <h1>마비노기 모바일 우연한만남 DISCORD</h1>
+    <p>파티 모집·랭킹 조회·인구 통계·알림·이벤트까지<br>모두 한 곳에서 간편하게!</p>
+    <button class="btn" onclick="location.href='https://discord.gg/mabinogi01'">
+      지금 디스코드 참여하기
+    </button>
+  </header>
+
+  <div class="container">
+    <!-- Features Section -->
+    <section class="features">
+      <div class="feature">
+        <div class="icon">🤝</div>
+        <h3>파티 모집</h3>
+        <p>간단 명령어로 파티 등록·참여자를 관리</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🔍</div>
+        <h3>랭킹 조회</h3>
+        <p>캐릭터명·서버명 입력으로 실시간 랭킹·점수·변동 확인</p>
+      </div>
+      <div class="feature">
+        <div class="icon">📊</div>
+        <h3>인구 통계</h3>
+        <p>서버별 인구수 통계를 한눈에 시각화</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🔔</div>
+        <h3>알림 기능</h3>
+        <p>경계·보스·심층 알림을 원하는 시간에 DM으로</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🎉</div>
+        <h3>서버 이벤트</h3>
+        <p>정기 이벤트로 기프티콘 증정·참여 보상 제공</p>
+      </div>
+    </section>
+
+    <!-- Event Details -->
+    <section class="event">
+      <h2>🎁 서버 활성화 이벤트 안내</h2>
+      <ul>
+        <li>매주 토요일~금요일 집계, 매주 일요일 보상 지급</li>
+        <li>심층 제보왕: 최다 제보자 1명에게 GS25 기프티콘 10,000원</li>
+        <li>심층 알림 구독: 추첨 3명에게 GS25 기프티콘 5,000원</li>
+        <li>파티 모집 클리어: 스크린샷 업로드 시 주간 추첨 보상</li>
+      </ul>
+    </section>
+  </div>
+
+  <!-- Call-to-Action Footer -->
+  <footer>
+    <button class="btn" onclick="location.href='https://discord.gg/mabinogi01'">
+      디스코드 채널 입장하기
+    </button>
+  </footer>
+
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a new "Introduce" feature to the application, including a new API endpoint, an HTML template for the introduction page, and necessary integrations into the main application. The most important changes are grouped below by theme.

### API Implementation:

* Added a new `introduce` API endpoint in `app/api/introduce.py` to serve an HTML introduction page. The endpoint checks for the existence of the `introduce.html` file and serves its content or an error message if the file is missing.

### Application Integration:

* Updated `app/main.py` to include the `introduce` router in the application's API routing. This includes importing the `introduce` module and adding the router with the `/introduce` prefix. [[1]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddL13-R13) [[2]](diffhunk://#diff-990f7e4140fab1ad82afc787505090b64d4024e63a891405cd9085e7e6b249ddR140)

### Frontend Design:

* Created a new `introduce.html` file in `app/templates` to provide a visually appealing introduction page. The page includes sections for a hero banner, feature highlights, event details, and a call-to-action footer, all styled with embedded CSS.